### PR TITLE
Remove Scalasti dependency, use Java StringTemplate

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -29,7 +29,7 @@ lazy val plugin = project
     libraryDependencies ++= Seq(
       "ch.epfl.lamp" %% "dotty-compiler" % scalaVersion.value % "provided",
       ("org.scala-lang.modules" %% "scala-parser-combinators" % "1.1.2").withDottyCompat(scalaVersion.value),
-      ("org.clapper" %% "scalasti" % "3.0.1").withDottyCompat(scalaVersion.value)
+      "org.antlr" % "ST4" % "4.1"
     ),
   )
 

--- a/plugin/src/main/scala/mcrl2/Property.scala
+++ b/plugin/src/main/scala/mcrl2/Property.scala
@@ -115,7 +115,7 @@ object Property {
                            extras: Map[String, Set[String]],
                            options: Options)
                           (implicit ctx: Context) extends Property {
-    import org.clapper.scalasti.ST
+    import org.stringtemplate.v4.ST
 
     override val variables: Set[String] = observed ++ relied
 
@@ -176,7 +176,9 @@ object Property {
         "observed_relied" -> observedReliedAttr,
         "observed_relied_probes" -> observedReliedProbesAttr
       ) ++ extras.map { (k, v) => k -> legendize(v) }
-      val res = ST(tpl, '$', '$').addAttributes(attrs).render().get
+      val res = attrs.foldLeft(ST(tpl, '$', '$')) { (acc, kv) =>
+        acc.add(kv._1, kv._2)
+      }.render
       ctx.log(s"Rendered MCF formula:\n${res}")
       Right(res)
     }


### PR DESCRIPTION
This simplifies porting Effpi to Dotty 0.18.1-RC1, that uses the Scala
2.13 standard library (Scalasti still depends on Scala 2.12)